### PR TITLE
Skip compression when paths are all empty

### DIFF
--- a/compression/compression.go
+++ b/compression/compression.go
@@ -1,6 +1,11 @@
 package compression
 
 import (
+	"errors"
+	"io"
+	"io/fs"
+	"os"
+
 	"github.com/bitrise-io/go-utils/v2/command"
 	"github.com/bitrise-io/go-utils/v2/env"
 	"github.com/bitrise-io/go-utils/v2/log"
@@ -31,4 +36,41 @@ func Compress(archivePath string, includePaths []string, logger log.Logger, envR
 	}
 
 	return nil
+}
+
+func AreAllPathsEmpty(includePaths []string) bool {
+	allEmpty := true
+
+	for _, path := range includePaths {
+		// Check if file exists at path
+		fileInfo, err := os.Stat(path)
+		if errors.Is(err, fs.ErrNotExist) {
+			// File doesn't exist
+			continue
+		}
+
+		// Check if it's a directory
+		if !fileInfo.IsDir() {
+			// Is a file and it exists
+			allEmpty = false
+			break
+		}
+
+		file, err := os.Open(path)
+		if err != nil {
+			continue
+		}
+		_, err = file.Readdirnames(1) // query only 1 child
+		if errors.Is(err, io.EOF) {
+			// Dir is empty
+			continue
+		}
+		if err == nil {
+			// Dir has files or dirs
+			allEmpty = false
+			break
+		}
+	}
+
+	return allEmpty
 }

--- a/compression/compression_test.go
+++ b/compression/compression_test.go
@@ -1,0 +1,88 @@
+package compression
+
+import (
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestAreAllPathsEmpty(t *testing.T) {
+	// Set up test dir structure
+	basePath := t.TempDir()
+	err := os.MkdirAll(filepath.Join(basePath, "empty_dir"), 0700)
+	if err != nil {
+		t.Fatalf(err.Error())
+	}
+	err = os.MkdirAll(filepath.Join(basePath, "dir_with_dir_child", "nested_empty_dir"), 0700)
+	if err != nil {
+		t.Fatalf(err.Error())
+	}
+	err = os.MkdirAll(filepath.Join(basePath, "first_level", "second_level"), 0700)
+	if err != nil {
+		t.Fatalf(err.Error())
+	}
+	err = ioutil.WriteFile(filepath.Join(basePath, "first_level", "second_level", "nested_file.txt"), []byte("hello"), 0700)
+	if err != nil {
+		t.Fatalf(err.Error())
+	}
+
+	tests := []struct {
+		name         string
+		includePaths []string
+		want         bool
+	}{
+		{
+			name: "single empty dir",
+			includePaths: []string{
+				filepath.Join(basePath, "empty_dir"),
+			},
+			want: true,
+		},
+		{
+			name: "dir with files",
+			includePaths: []string{
+				filepath.Join(basePath, "first_level", "second_level", "nested_file.txt"),
+			},
+			want: false,
+		},
+		{
+			name: "empty dir within dir",
+			includePaths: []string{
+				filepath.Join(basePath, "dir_with_dir_child"),
+			},
+			want: false,
+		},
+		{
+			name: "empty and non-empty dirs",
+			includePaths: []string{
+				filepath.Join(basePath, "empty_dir"),
+				filepath.Join(basePath, "first_level"),
+			},
+			want: false,
+		},
+		{
+			name: "nonexistent dir",
+			includePaths: []string{
+				filepath.Join(basePath, "this doesn't exist"),
+			},
+			want: true,
+		},
+		{
+			name: "file path",
+			includePaths: []string{
+				filepath.Join(basePath, "this doesn't exist"),
+				filepath.Join(basePath, "empty_dir"),
+				filepath.Join(basePath, "first_level", "second_level", "nested_file.txt"),
+			},
+			want: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := AreAllPathsEmpty(tt.includePaths); got != tt.want {
+				t.Errorf("AreAllPathsEmpty() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/e2e/bitrise.yml
+++ b/e2e/bitrise.yml
@@ -106,15 +106,10 @@ workflows:
         title: Delete _tmp dir
         inputs:
         - content: rm -rf _tmp
-    - change-workdir:
-        title: Switch working dir to _tmp
-        inputs:
-        - path: ./_tmp
-        - is_create_path: true
     - git::https://github.com/bitrise-steplib/bitrise-step-simple-git-clone.git:
         inputs:
         - repository_url: $TEST_APP_URL
-        - clone_into_dir: .
+        - clone_into_dir: ./_tmp
         - branch: $BRANCH
 
   _generate_api_token:

--- a/e2e/bitrise.yml
+++ b/e2e/bitrise.yml
@@ -54,8 +54,8 @@ workflows:
 
   test_empty:
     description: |
-      Tests the case when there is nothing to compress based on the cache paths. The step is marked as skippable,
-      so it should not fail the entire workflow.
+      Tests the case when there is nothing to compress based on the cache paths. The step returns early in this case
+      with a 0 exit code
     before_run:
     - _generate_api_token
     steps:

--- a/e2e/bitrise.yml
+++ b/e2e/bitrise.yml
@@ -29,7 +29,6 @@ workflows:
     envs:
     - TEST_APP_URL: https://github.com/bitrise-io/Bitrise-React-Native-Sample
     - BRANCH: master
-    - BITRISE_SOURCE_DIR: .
     before_run:
     - _generate_api_token
     - _setup
@@ -53,11 +52,31 @@ workflows:
             node_modules
         - verbose: "true"
 
+  test_empty:
+    description: |
+      Tests the case when there is nothing to compress based on the cache paths. The step is marked as skippable,
+      so it should not fail the entire workflow.
+    before_run:
+    - _generate_api_token
+    steps:
+    - change-workdir:
+        title: Switch working dir to _tmp
+        inputs:
+        - path: ./_tmp
+        - is_create_path: true
+    - path::./:
+        title: Execute step
+        run_if: "true"
+        inputs:
+        - key: node-modules-{{ checksum "package-lock.json" }}
+        - paths: |-
+            node_modules
+        - verbose: "true"
+
   test_gradle:
     envs:
     - TEST_APP_URL: https://github.com/bitrise-io/Bitrise-Android-Sample
     - BRANCH: main
-    - BITRISE_SOURCE_DIR: .
     before_run:
     - _generate_api_token
     - _setup

--- a/step.yml
+++ b/step.yml
@@ -9,6 +9,7 @@ type_tags:
 - utility
 
 run_if: .IsCI
+is_skippable: true
 
 toolkit:
   go:

--- a/step.yml
+++ b/step.yml
@@ -9,7 +9,6 @@ type_tags:
 - utility
 
 run_if: .IsCI
-is_skippable: true
 
 toolkit:
   go:

--- a/step/step.go
+++ b/step/step.go
@@ -157,7 +157,7 @@ func (step SaveCacheStep) evaluateKey(keyTemplate string) (string, error) {
 func (step SaveCacheStep) compress(paths []string) (string, error) {
 	if compression.AreAllPathsEmpty(paths) {
 		step.logger.Warnf("The provided paths are all empty, skipping compression and upload.")
-		os.Exit(1)
+		os.Exit(0)
 	}
 
 	fileName := fmt.Sprintf("cache-%s.tzst", time.Now().UTC().Format("20060102-150405"))

--- a/step/step.go
+++ b/step/step.go
@@ -155,6 +155,11 @@ func (step SaveCacheStep) evaluateKey(keyTemplate string) (string, error) {
 }
 
 func (step SaveCacheStep) compress(paths []string) (string, error) {
+	if compression.AreAllPathsEmpty(paths) {
+		step.logger.Warnf("The provided paths are all empty, skipping compression and upload.")
+		os.Exit(1)
+	}
+
 	fileName := fmt.Sprintf("cache-%s.tzst", time.Now().UTC().Format("20060102-150405"))
 	tempDir, err := step.pathProvider.CreateTempDir("save-cache")
 	if err != nil {


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our Step library!
  Please fill this template with the details of your change.
-->

### Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. This is simply a reminder of what we are going to look
  for before merging your code.
-->
- [ ] I've read and followed the [Contribution Guidelines](https://github.com/bitrise-steplib/.github/blob/main/CONTRIBUTING.md)
- [ ] `step.yml` and `README.md` is updated with the changes (if needed)

### Version
<!-- Leave this untouched if you don't know, we'll help -->
Requires a *MAJOR/MINOR/PATCH* [version update](https://semver.org/)

### Context

The `tar` command fails if it detects that there is nothing to compress:

![image](https://user-images.githubusercontent.com/1694986/183046994-f0d5ec07-15e1-4584-8951-4977822ad638.png)

We should detect this case early and skip the rest of the step.

<!-- Please link the issue that the PR fixes.
Resolves: #GITHUB_ISSUE_ID or https://link_to_the_issue_on_discuss.bitrise.io.
-->

### Changes

- Detect if all paths are empty and exit the step early

### Investigation details

<!-- Please share any alternative solutions that were considered along with investigation details. -->

### Decisions

<!-- Please list decisions that were made for this change. -->
