### PR TITLE
Fine tune compression params

### DIFF
--- a/compression/compression.go
+++ b/compression/compression.go
@@ -16,8 +16,8 @@ func Compress(archivePath string, includePaths []string, logger log.Logger, envR
 
 	tarArgs := []string{
 		"--use-compress-program",
-		"zstd --threads=0 --long", // Use CPU count threads, enable long distance matching
-		"-P",                      // Same as --absolute-paths in BSD tar, --absolute-names in GNU tar
+		"zstd --threads=0", // Use CPU count threads
+		"-P",               // Same as --absolute-paths in BSD tar, --absolute-names in GNU tar
 		"-cf",
 		archivePath,
 		"--directory",


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our Step library!
  Please fill this template with the details of your change.
-->

### Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. This is simply a reminder of what we are going to look
  for before merging your code.
-->
- [ ] I've read and followed the [Contribution Guidelines](https://github.com/bitrise-steplib/.github/blob/main/CONTRIBUTING.md)
- [ ] `step.yml` and `README.md` is updated with the changes (if needed)

### Version
<!-- Leave this untouched if you don't know, we'll help -->
Requires no [version update](https://semver.org/)

### Context

Fine-tuning zstd's compression parameters for our use case.

### Changes

Disable long-distance matching. Based on my benchmarks, long-distance matching improves compression ratio very little, but slows down compression significantly (especially on Linux)

### Investigation details

I made the benchmarks on Bitrise VMs using zstd's benchmark mode and a tar of a typical Gradle build cache.

Commands:

```
tar -cf test.tar ~/.gradle/caches ~/.gradle/wrapper

zstd -b3 -T0 test.tar

zstd -b3 -T0 --long test.tar
```

Results:

Numbers are: compression ratio, compression speed, decompression speed

Linux (Standard VM):

```
1.4.4:
-b3 -T0: (1.921), 551.4 MB/s ,1595.3 MB/s
-b3 -T0 --long: (2.089), 257.3 MB/s ,1705.2 MB/s

1.5.3:
-b3 -T0: (x1.920),  576.3 MB/s, 1788.7 MB/s
-b3 -T0 --long: (x2.084),  414.3 MB/s, 1943.3 MB/s
```

Linux uses an older version of zstd, the latest version has some speed gains, but `--long` is still a lot slower.

macOS:

```
macOS Intel (Elite):
1.5.2:
-b3 -T0: (x1.955), 1078.7 MB/s, 1815.8 MB/s
-b3 -T0 --long: (x2.111),  927.3 MB/s, 1880.2 MB/s

macOS M1 (EliteXL):
1.5.2:
-b3 -T0: (x1.955), 2406.7 MB/s, 2237.9 MB/s
-b3 -T0 --long: (x2.111),  909.2 MB/s, 2389.0 MB/s
```

### Decisions

<!-- Please list decisions that were made for this change. -->
