### PR TITLE
Support wildcards in path input

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/bitrise-steplib/bitrise-step-save-cache
 go 1.17
 
 require (
-	github.com/bitrise-io/go-steputils/v2 v2.0.0-alpha.6.0.20220712151948-c7363f149b37
+	github.com/bitrise-io/go-steputils/v2 v2.0.0-alpha.9
 	github.com/bitrise-io/go-utils/v2 v2.0.0-alpha.11
 	github.com/bmatcuk/doublestar/v4 v4.2.0
 	github.com/docker/go-units v0.4.0

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.17
 require (
 	github.com/bitrise-io/go-steputils/v2 v2.0.0-alpha.6.0.20220712151948-c7363f149b37
 	github.com/bitrise-io/go-utils/v2 v2.0.0-alpha.11
+	github.com/bmatcuk/doublestar/v4 v4.2.0
 	github.com/docker/go-units v0.4.0
 	github.com/hashicorp/go-retryablehttp v0.7.1
 	github.com/stretchr/testify v1.7.0
@@ -12,7 +13,6 @@ require (
 
 require (
 	github.com/bitrise-io/go-utils v1.0.1 // indirect
-	github.com/bmatcuk/doublestar/v4 v4.2.0 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/hashicorp/go-cleanhttp v0.5.2 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,7 @@
 github.com/bitrise-io/go-steputils v1.0.1 h1:lwPl2W1njfANrBoTCkuqOOYbTha263ZFqoWQH0fwhaY=
 github.com/bitrise-io/go-steputils v1.0.1/go.mod h1:YIUaQnIAyK4pCvQG0hYHVkSzKNT9uL2FWmkFNW4mfNI=
-github.com/bitrise-io/go-steputils/v2 v2.0.0-alpha.6.0.20220712151948-c7363f149b37 h1:T7H5cebm0uzJDBPxHSsUzUOqtoE13zheEmysQPhz7oo=
-github.com/bitrise-io/go-steputils/v2 v2.0.0-alpha.6.0.20220712151948-c7363f149b37/go.mod h1:5ES6ToS2nIMou3poXmtYj+aRyjyi6hVE7KBNGnPkaso=
+github.com/bitrise-io/go-steputils/v2 v2.0.0-alpha.9 h1:jQcWILcB5lInVFuYdeOQG2cZCMUGSRZuAB2++NV9v5Y=
+github.com/bitrise-io/go-steputils/v2 v2.0.0-alpha.9/go.mod h1:5ES6ToS2nIMou3poXmtYj+aRyjyi6hVE7KBNGnPkaso=
 github.com/bitrise-io/go-utils v1.0.1 h1:e7mepVBkVN1DXRPESNXb0djEw6bxB6B93p/Q74zzcvk=
 github.com/bitrise-io/go-utils v1.0.1/go.mod h1:ZY1DI+fEpZuFpO9szgDeICM4QbqoWVt0RSY3tRI1heY=
 github.com/bitrise-io/go-utils/v2 v2.0.0-alpha.1/go.mod h1:sy+Ir1X8P3tAAx/qU/r+hqDjHDcrMjIzDEvId1wqNc4=

--- a/step/step_test.go
+++ b/step/step_test.go
@@ -50,16 +50,19 @@ func Test_ProcessConfig(t *testing.T) {
 			wantErr: false,
 		},
 		{
-			name: "Multiple file paths",
+			name: "Multiple file paths with wildcards",
 			inputParser: fakeInputParser{
 				verbose: false,
 				key:     "cache-key",
-				paths:   "testdata/dummy_file.txt\ntestdata/subfolder/nested_file.txt",
+				paths:   "testdata/dummy_file.txt\ntestdata/**/nested_*.txt",
 			},
 			want: &Config{
-				Verbose:        false,
-				Key:            "cache-key",
-				Paths:          []string{filepath.Join(testdataAbsPath, "dummy_file.txt"), filepath.Join(testdataAbsPath, "subfolder", "nested_file.txt")},
+				Verbose: false,
+				Key:     "cache-key",
+				Paths: []string{
+					filepath.Join(testdataAbsPath, "dummy_file.txt"),
+					filepath.Join(testdataAbsPath, "subfolder", "nested_file.txt"),
+				},
 				APIBaseURL:     "fake cache service URL",
 				APIAccessToken: "fake cache service access token",
 			},

--- a/vendor/github.com/bitrise-io/go-steputils/v2/cache/keytemplate/checksum.go
+++ b/vendor/github.com/bitrise-io/go-steputils/v2/cache/keytemplate/checksum.go
@@ -20,6 +20,7 @@ func (m Model) checksum(paths ...string) string {
 		m.logger.Errorf(err.Error())
 		return ""
 	}
+
 	files := m.evaluateGlobPatterns(workingDir, paths)
 	m.logger.Debugf("Files included in checksum:")
 	for _, path := range files {
@@ -73,7 +74,7 @@ func (m Model) evaluateGlobPatterns(workingDir string, paths []string) []string 
 		}
 	}
 
-	return finalPaths
+	return filterFilesOnly(finalPaths)
 }
 
 func checksumOfFile(path string) ([]byte, error) {
@@ -84,4 +85,20 @@ func checksumOfFile(path string) ([]byte, error) {
 	}
 	hash.Write(b)
 	return hash.Sum(nil), nil
+}
+
+func filterFilesOnly(paths []string) []string {
+	var files []string
+	for _, path := range paths {
+		info, err := os.Stat(path)
+		if err != nil {
+			continue
+		}
+		if info.IsDir() {
+			continue
+		}
+		files = append(files, path)
+	}
+
+	return files
 }

--- a/vendor/github.com/bitrise-io/go-steputils/v2/cache/keytemplate/keytemplate.go
+++ b/vendor/github.com/bitrise-io/go-steputils/v2/cache/keytemplate/keytemplate.go
@@ -87,6 +87,6 @@ func (m Model) validateInventory(inventory templateInventory) {
 
 func (m Model) warnIfEmpty(name, value string) {
 	if value == "" {
-		m.logger.Warnf("Template variable .%s is not defined", name)
+		m.logger.Debugf("Template variable .%s is not defined", name)
 	}
 }

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1,4 +1,4 @@
-# github.com/bitrise-io/go-steputils/v2 v2.0.0-alpha.6.0.20220712151948-c7363f149b37
+# github.com/bitrise-io/go-steputils/v2 v2.0.0-alpha.9
 ## explicit; go 1.16
 github.com/bitrise-io/go-steputils/v2/cache/keytemplate
 github.com/bitrise-io/go-steputils/v2/stepconf


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our Step library!
  Please fill this template with the details of your change.
-->

### Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. This is simply a reminder of what we are going to look
  for before merging your code.
-->
- [ ] I've read and followed the [Contribution Guidelines](https://github.com/bitrise-steplib/.github/blob/main/CONTRIBUTING.md)
- [ ] `step.yml` and `README.md` is updated with the changes (if needed)

### Version
<!-- Leave this untouched if you don't know, we'll help -->
Requires a *MAJOR/MINOR/PATCH* [version update](https://semver.org/)

### Context

The path input should support and evaluate paths that contain wildcards, such as **/build or **/build.gradle*.

<!-- Please link the issue that the PR fixes.
Resolves: #GITHUB_ISSUE_ID or https://link_to_the_issue_on_discuss.bitrise.io.
-->

### Changes

- Move path parsing into its own function
- Expand wildcard paths into a list of matched paths
- Update go-steputils to pull 2 fixes for key template handling

### Investigation details

<!-- Please share any alternative solutions that were considered along with investigation details. -->

### Decisions

<!-- Please list decisions that were made for this change. -->
