### PR TITLE
Fix pattern matching in absolute paths

### DIFF
--- a/step/step_test.go
+++ b/step/step_test.go
@@ -59,7 +59,7 @@ func Test_ProcessConfig(t *testing.T) {
 			inputParser: fakeInputParser{
 				verbose: false,
 				key:     "cache-key",
-				paths:   "~/.bash_*",
+				paths:   "~/.bash_h*",
 			},
 			want: &Config{
 				Verbose:        false,

--- a/step/step_test.go
+++ b/step/step_test.go
@@ -1,6 +1,7 @@
 package step
 
 import (
+	"os"
 	"path/filepath"
 	"reflect"
 	"testing"
@@ -14,7 +15,11 @@ import (
 func Test_ProcessConfig(t *testing.T) {
 	testdataAbsPath, err := filepath.Abs("testdata")
 	if err != nil {
-		t.Errorf(err.Error())
+		t.Fatalf(err.Error())
+	}
+	homeAbsPath, err := os.UserHomeDir()
+	if err != nil {
+		t.Fatalf(err.Error())
 	}
 
 	tests := []struct {
@@ -44,6 +49,22 @@ func Test_ProcessConfig(t *testing.T) {
 				Verbose:        false,
 				Key:            "cache-key",
 				Paths:          []string{filepath.Join(testdataAbsPath, "dummy_file.txt")},
+				APIBaseURL:     "fake cache service URL",
+				APIAccessToken: "fake cache service access token",
+			},
+			wantErr: false,
+		},
+		{
+			name: "Absolute path and tilde in pattern path",
+			inputParser: fakeInputParser{
+				verbose: false,
+				key:     "cache-key",
+				paths:   "~/.bash_*",
+			},
+			want: &Config{
+				Verbose:        false,
+				Key:            "cache-key",
+				Paths:          []string{filepath.Join(homeAbsPath, ".bash_history")},
 				APIBaseURL:     "fake cache service URL",
 				APIAccessToken: "fake cache service access token",
 			},


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our Step library!
  Please fill this template with the details of your change.
-->

### Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. This is simply a reminder of what we are going to look
  for before merging your code.
-->
- [ ] I've read and followed the [Contribution Guidelines](https://github.com/bitrise-steplib/.github/blob/main/CONTRIBUTING.md)
- [ ] `step.yml` and `README.md` is updated with the changes (if needed)

### Version
<!-- Leave this untouched if you don't know, we'll help -->
Requires a *MAJOR/MINOR/PATCH* [version update](https://semver.org/)

### Context

Pattern matching in the `paths` input is not working when the path is an absolute path (or one that gets expanded to an absolute path), such as:

```
~/Library/Developer/Xcode/DerivedData/**/SourcePackages
```

### Changes

Fix glob pattern matching by splitting the path input into a base path and a pattern. Relevant section from the docs of `doublestar.Glob()`:

> // Like `io/fs.Glob()`, patterns containing `/./`, `/../`, or starting with `/`
> // will return no results and no errors. You can use SplitPattern to divide a
> // pattern into a base path (to initialize an `FS` object) and pattern.

### Investigation details

<!-- Please share any alternative solutions that were considered along with investigation details. -->

### Decisions

<!-- Please list decisions that were made for this change. -->
