### PR TITLE
Skip saving the cache if possible

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,10 @@ The most straightforward use case is when both the **Save cache** and **Restore 
 
 Unlike this Step, the **Restore cache** Step can define multiple keys as fallbacks when there is no match for the first cache key. See the docs of the **Restore cache** Step for more details.
 
+#### Skip saving the cache
+
+The Step can decide to skip saving a new cache entry to avoid unnecessary work. This happens when there is a previously restored cache in the same workflow and the new cache would have the same contents as the one restored. Make sure to use unique cache keys with a checksum, and enable the **Unique cache key** input for the most optimal execution.
+
 #### Related steps
 
 [Restore cache](https://github.com/bitrise-steplib/bitrise-step-restore-cache/)
@@ -126,6 +130,7 @@ steps:
 | `key` | Key used for saving a cache archive.  The key supports template elements for creating dynamic cache keys. These dynamic keys change the final key value based on the build environment or files in the repo in order to create new cache archives. See the Step description for more details and examples.  The maximum length of a key is 512 characters (longer keys get truncated). Commas (`,`) are not allowed in keys. | required |  |
 | `paths` | List of files and folders to include in the cache.  The path can contain wildcards (`*` and `**`) that are evaluated at runtime. | required |  |
 | `verbose` | Enable logging additional information for troubleshooting | required | `false` |
+| `is_key_unique` | Enabling this allows the Step to skip creating a new cache archive when the workflow previously restored the cache with the same key.  This requires the cache key to be unique, so that the key changes whenever the files in the cache change. In practice, this means adding a `checksum` part to the key template with a file that describes the cache content (such as a lockfile).  Example of a cache key where this can be safely turned on: `npm-cache-{{ checksum "package-lock.json" }}`. On the other hand, `my-cache-{{ .OS }}-{{ .Arch }}` is not unique (even though it uses templates).  Note: the Step can still skip uploading a cache when this input is `false`, it just needs to create the archive first to compute its checksum (which takes time). |  | `false` |
 </details>
 
 <details>

--- a/e2e/bitrise.yml
+++ b/e2e/bitrise.yml
@@ -39,7 +39,7 @@ workflows:
         title: Remove node_modules
         inputs:
         - content: rm -rf node_modules
-    - restore-cache:
+    - git::https://github.com/bitrise-steplib/bitrise-step-restore-cache.git@main:
         run_if: "true"
         is_skippable: false
         inputs:
@@ -134,7 +134,7 @@ workflows:
         title: Remove node_modules
         inputs:
         - content: rm -rf node_modules
-    - restore-cache:
+    - git::https://github.com/bitrise-steplib/bitrise-step-restore-cache.git@main:
         run_if: "true"
         is_skippable: false
         inputs:

--- a/e2e/bitrise.yml
+++ b/e2e/bitrise.yml
@@ -102,6 +102,55 @@ workflows:
             .gradle/configuration-cache
         - verbose: "true"
 
+  test_save_skip:
+    envs:
+    - TEST_APP_URL: https://github.com/bitrise-io/Bitrise-React-Native-Sample
+    - BRANCH: master
+    before_run:
+    - _generate_api_token
+    - _setup
+    steps:
+    - change-workdir:
+        title: Switch working dir to _tmp
+        inputs:
+        - path: ./_tmp
+    - script:
+        title: Install dependencies
+        inputs:
+        - content: |-
+            set -ex
+            npm ci
+    - path::./:
+        title: Execute step for first time
+        run_if: "true"
+        is_skippable: false
+        inputs:
+        - key: node-modules-{{ checksum "package-lock.json" }}
+        - paths: |-
+            node_modules
+        - verbose: "true"
+        - is_key_unique: "true"
+    - script:
+        title: Remove node_modules
+        inputs:
+        - content: rm -rf node_modules
+    - restore-cache:
+        run_if: "true"
+        is_skippable: false
+        inputs:
+        - key: node-modules-{{ checksum "package-lock.json" }}
+        - verbose: "true"
+    - path::./:
+        title: Execute step after restore
+        run_if: "true"
+        is_skippable: false
+        inputs:
+        - key: node-modules-{{ checksum "package-lock.json" }}
+        - paths: |-
+            node_modules
+        - verbose: "true"
+        - is_key_unique: "true"
+
   _setup:
     steps:
     - script:

--- a/go.mod
+++ b/go.mod
@@ -3,11 +3,12 @@ module github.com/bitrise-steplib/bitrise-step-save-cache
 go 1.17
 
 require (
-	github.com/bitrise-io/go-steputils/v2 v2.0.0-alpha.11
+	github.com/bitrise-io/go-steputils/v2 v2.0.0-alpha.13
 	github.com/bitrise-io/go-utils/v2 v2.0.0-alpha.12
 )
 
 require (
+	github.com/bitrise-io/go-steputils v1.0.1 // indirect
 	github.com/bitrise-io/go-utils v1.0.1 // indirect
 	github.com/bmatcuk/doublestar/v4 v4.2.0 // indirect
 	github.com/docker/go-units v0.4.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,7 @@
 github.com/bitrise-io/go-steputils v1.0.1 h1:lwPl2W1njfANrBoTCkuqOOYbTha263ZFqoWQH0fwhaY=
 github.com/bitrise-io/go-steputils v1.0.1/go.mod h1:YIUaQnIAyK4pCvQG0hYHVkSzKNT9uL2FWmkFNW4mfNI=
-github.com/bitrise-io/go-steputils/v2 v2.0.0-alpha.11 h1:pZh86Qhym0SBROszhLs+hgBbQUOWcbVjWFAheaTAwDQ=
-github.com/bitrise-io/go-steputils/v2 v2.0.0-alpha.11/go.mod h1:ub3KVohX1vc1f2alPeVg7EoXAifm7p+SD326c2OUKdo=
+github.com/bitrise-io/go-steputils/v2 v2.0.0-alpha.13 h1:u0a7tQAtbwBwkGlPqTkXib92GItRknyNRukpqV8Cpeo=
+github.com/bitrise-io/go-steputils/v2 v2.0.0-alpha.13/go.mod h1:ub3KVohX1vc1f2alPeVg7EoXAifm7p+SD326c2OUKdo=
 github.com/bitrise-io/go-utils v1.0.1 h1:e7mepVBkVN1DXRPESNXb0djEw6bxB6B93p/Q74zzcvk=
 github.com/bitrise-io/go-utils v1.0.1/go.mod h1:ZY1DI+fEpZuFpO9szgDeICM4QbqoWVt0RSY3tRI1heY=
 github.com/bitrise-io/go-utils/v2 v2.0.0-alpha.12 h1:FxzmUw3B3eQuxPxBFN/oORunIdxSBqZgJZmRb8CAiTc=

--- a/step.yml
+++ b/step.yml
@@ -44,6 +44,10 @@ description: |
 
   Unlike this Step, the **Restore cache** Step can define multiple keys as fallbacks when there is no match for the first cache key. See the docs of the **Restore cache** Step for more details.
 
+  #### Skip saving the cache
+
+  The Step can decide to skip saving a new cache entry to avoid unnecessary work. This happens when there is a previously restored cache in the same workflow and the new cache would have the same contents as the one restored. Make sure to use unique cache keys with a checksum, and enable the **Unique cache key** input for the most optimal execution.
+
   #### Related steps
 
   [Restore cache](https://github.com/bitrise-steplib/bitrise-step-restore-cache/)
@@ -99,3 +103,16 @@ inputs:
     value_options:
     - "true"
     - "false"
+
+- is_key_unique: "false"
+  opts:
+    title: Unique cache key
+    summary: This allows the Step to skip creating a new cache in certain conditions. Only set to `true` if the key is unique to the cached content!
+    description: |-
+      Enabling this allows the Step to skip creating a new cache archive when the workflow previously restored the cache with the same key.
+
+      This requires the cache key to be unique, so that the key changes whenever the files in the cache change. In practice, this means adding a `checksum` part to the key template with a file that describes the cache content (such as a lockfile).
+
+      Example of a cache key where this can be safely turned on: `npm-cache-{{ checksum "package-lock.json" }}`. On the other hand, `my-cache-{{ .OS }}-{{ .Arch }}` is not unique (even though it uses templates).
+
+      Note: the Step can still skip uploading a cache when this input is `false`, it just needs to create the archive first to compute its checksum (which takes time).

--- a/step/step.go
+++ b/step/step.go
@@ -13,9 +13,10 @@ import (
 )
 
 type Input struct {
-	Verbose bool   `env:"verbose,required"`
-	Key     string `env:"key,required"`
-	Paths   string `env:"paths,required"`
+	Verbose     bool   `env:"verbose,required"`
+	Key         string `env:"key,required"`
+	Paths       string `env:"paths,required"`
+	IsKeyUnique bool   `env:"is_key_unique"`
 }
 
 type SaveCacheStep struct {
@@ -52,9 +53,10 @@ func (step SaveCacheStep) Run() error {
 
 	saver := cache.NewSaver(step.envRepo, step.logger, step.pathProvider, step.pathModifier, step.pathChecker)
 	return saver.Save(cache.SaveCacheInput{
-		StepId:  "save-cache",
-		Verbose: input.Verbose,
-		Key:     input.Key,
-		Paths:   strings.Split(input.Paths, "\n"),
+		StepId:      "save-cache",
+		Verbose:     input.Verbose,
+		Key:         input.Key,
+		Paths:       strings.Split(input.Paths, "\n"),
+		IsKeyUnique: input.IsKeyUnique,
 	})
 }

--- a/vendor/github.com/bitrise-io/go-steputils/tools/tools.go
+++ b/vendor/github.com/bitrise-io/go-steputils/tools/tools.go
@@ -1,0 +1,14 @@
+package tools
+
+import (
+	"strings"
+
+	"github.com/bitrise-io/go-utils/command"
+)
+
+// ExportEnvironmentWithEnvman ...
+func ExportEnvironmentWithEnvman(key, value string) error {
+	cmd := command.New("envman", "add", "--key", key)
+	cmd.SetStdin(strings.NewReader(value))
+	return cmd.Run()
+}

--- a/vendor/github.com/bitrise-io/go-steputils/v2/cache/common.go
+++ b/vendor/github.com/bitrise-io/go-steputils/v2/cache/common.go
@@ -1,0 +1,28 @@
+package cache
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"io"
+	"os"
+)
+
+// We need this prefix because there could be multiple restore steps in one workflow with multiple cache keys
+const cacheHitEnvVarPrefix = "BITRISE_CACHE_HIT__"
+
+func checksumOfFile(path string) (string, error) {
+	hash := sha256.New()
+
+	file, err := os.Open(path)
+	if err != nil {
+		return "", err
+	}
+	defer file.Close() //nolint:errcheck
+
+	_, err = io.Copy(hash, file)
+	if err != nil {
+		return "", err
+	}
+
+	return hex.EncodeToString(hash.Sum(nil)), nil
+}

--- a/vendor/github.com/bitrise-io/go-steputils/v2/cache/keytemplate/checksum.go
+++ b/vendor/github.com/bitrise-io/go-steputils/v2/cache/keytemplate/checksum.go
@@ -3,6 +3,7 @@ package keytemplate
 import (
 	"crypto/sha256"
 	"encoding/hex"
+	"io"
 	"os"
 	"path/filepath"
 	"sort"
@@ -83,11 +84,17 @@ func (m Model) evaluateGlobPatterns(paths []string) []string {
 
 func checksumOfFile(path string) ([]byte, error) {
 	hash := sha256.New()
-	b, err := os.ReadFile(path)
+	file, err := os.Open(path)
 	if err != nil {
 		return nil, err
 	}
-	hash.Write(b)
+	defer file.Close() //nolint:errcheck
+
+	_, err = io.Copy(hash, file)
+	if err != nil {
+		return nil, err
+	}
+
 	return hash.Sum(nil), nil
 }
 

--- a/vendor/github.com/bitrise-io/go-steputils/v2/cache/network/download.go
+++ b/vendor/github.com/bitrise-io/go-steputils/v2/cache/network/download.go
@@ -23,31 +23,31 @@ var ErrCacheNotFound = errors.New("no cache archive found for the provided keys"
 
 // Download archive from the cache API based on the provided keys in params.
 // If there is no match for any of the keys, the error is ErrCacheNotFound.
-func Download(params DownloadParams, logger log.Logger) error {
+func Download(params DownloadParams, logger log.Logger) (matchedKey string, err error) {
 	if params.APIBaseURL == "" {
-		return fmt.Errorf("API base URL is empty")
+		return "", fmt.Errorf("API base URL is empty")
 	}
 
 	if params.Token == "" {
-		return fmt.Errorf("API token is empty")
+		return "", fmt.Errorf("API token is empty")
 	}
 
 	if len(params.CacheKeys) == 0 {
-		return fmt.Errorf("cache key list is empty")
+		return "", fmt.Errorf("cache key list is empty")
 	}
 
 	client := newAPIClient(retryhttp.NewClient(logger), params.APIBaseURL, params.Token)
 
 	logger.Debugf("Get download URL")
-	url, err := client.restore(params.CacheKeys)
+	restoreResponse, err := client.restore(params.CacheKeys)
 	if err != nil {
-		return fmt.Errorf("failed to get download URL: %w", err)
+		return "", fmt.Errorf("failed to get download URL: %w", err)
 	}
 
 	logger.Debugf("Download archive")
 	file, err := os.Create(params.DownloadPath)
 	if err != nil {
-		return fmt.Errorf("can't open download location: %w", err)
+		return "", fmt.Errorf("can't open download location: %w", err)
 	}
 	defer func(file *os.File) {
 		err := file.Close()
@@ -56,9 +56,9 @@ func Download(params DownloadParams, logger log.Logger) error {
 		}
 	}(file)
 
-	respBody, err := client.downloadArchive(url)
+	respBody, err := client.downloadArchive(restoreResponse.URL)
 	if err != nil {
-		return fmt.Errorf("failed to download archive: %w", err)
+		return "", fmt.Errorf("failed to download archive: %w", err)
 	}
 	defer func(respBody io.ReadCloser) {
 		err := respBody.Close()
@@ -68,8 +68,8 @@ func Download(params DownloadParams, logger log.Logger) error {
 	}(respBody)
 	_, err = io.Copy(file, respBody)
 	if err != nil {
-		return fmt.Errorf("failed to save archive to disk: %w", err)
+		return "", fmt.Errorf("failed to save archive to disk: %w", err)
 	}
 
-	return nil
+	return restoreResponse.MatchedKey, nil
 }

--- a/vendor/github.com/bitrise-io/go-steputils/v2/cache/restore.go
+++ b/vendor/github.com/bitrise-io/go-steputils/v2/cache/restore.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 	"time"
 
+	"github.com/bitrise-io/go-steputils/tools"
 	"github.com/bitrise-io/go-steputils/v2/cache/compression"
 	"github.com/bitrise-io/go-steputils/v2/cache/keytemplate"
 	"github.com/bitrise-io/go-steputils/v2/cache/network"
@@ -41,6 +42,11 @@ type restorer struct {
 	logger  log.Logger
 }
 
+type downloadResult struct {
+	filePath   string
+	matchedKey string
+}
+
 // NewRestorer ...
 func NewRestorer(envRepo env.Repository, logger log.Logger) *restorer {
 	return &restorer{envRepo: envRepo, logger: logger}
@@ -58,15 +64,23 @@ func (r *restorer) Restore(input RestoreCacheInput) error {
 	r.logger.Println()
 	r.logger.Infof("Downloading archive...")
 	downloadStartTime := time.Now()
-	archivePath, err := r.download(config)
+	result, err := r.download(config)
 	if err != nil {
 		if errors.Is(err, network.ErrCacheNotFound) {
 			r.logger.Donef("No cache entry found for the provided key")
+			tracker.logRestoreResult(false, "", config.Keys)
+			tracker.wait()
 			return nil
 		}
 		return fmt.Errorf("download failed: %w", err)
 	}
-	fileInfo, err := os.Stat(archivePath)
+	if result.matchedKey == config.Keys[0] {
+		r.logger.Printf("Exact hit for first key")
+	} else {
+		r.logger.Printf("Cache hit for key: %s", result.matchedKey)
+	}
+
+	fileInfo, err := os.Stat(result.filePath)
 	if err != nil {
 		return err
 	}
@@ -78,14 +92,20 @@ func (r *restorer) Restore(input RestoreCacheInput) error {
 	r.logger.Println()
 	r.logger.Infof("Restoring archive...")
 	extractionStartTime := time.Now()
-	if err := compression.Decompress(archivePath, r.logger, r.envRepo); err != nil {
+	if err := compression.Decompress(result.filePath, r.logger, r.envRepo); err != nil {
 		return fmt.Errorf("failed to decompress cache archive: %w", err)
 	}
 	extractionTime := time.Since(extractionStartTime).Round(time.Second)
 	r.logger.Donef("Restored archive in %s", extractionTime)
 	tracker.logArchiveExtracted(extractionTime, len(config.Keys))
-	tracker.wait()
 
+	err = r.exposeCacheHit(result)
+	if err != nil {
+		return err
+	}
+
+	tracker.logRestoreResult(true, result.matchedKey, config.Keys)
+	tracker.wait()
 	return nil
 }
 
@@ -114,11 +134,6 @@ func (r *restorer) createConfig(input RestoreCacheInput) (restoreCacheConfig, er
 
 func (r *restorer) evaluateKeys(keys []string) ([]string, error) {
 	model := keytemplate.NewModel(r.envRepo, r.logger)
-	buildContext := keytemplate.BuildContext{
-		Workflow:   r.envRepo.Get("BITRISE_TRIGGERED_WORKFLOW_ID"),
-		Branch:     r.envRepo.Get("BITRISE_GIT_BRANCH"),
-		CommitHash: r.envRepo.Get("BITRISE_GIT_COMMIT"),
-	}
 
 	var evaluatedKeys []string
 	for _, key := range keys {
@@ -128,7 +143,7 @@ func (r *restorer) evaluateKeys(keys []string) ([]string, error) {
 
 		r.logger.Println()
 		r.logger.Printf("Evaluating key template: %s", key)
-		evaluatedKey, err := model.Evaluate(key, buildContext)
+		evaluatedKey, err := model.Evaluate(key)
 		if err != nil {
 			return nil, fmt.Errorf("failed to evaluate key template: %s", err)
 		}
@@ -139,10 +154,10 @@ func (r *restorer) evaluateKeys(keys []string) ([]string, error) {
 	return evaluatedKeys, nil
 }
 
-func (r *restorer) download(config restoreCacheConfig) (string, error) {
+func (r *restorer) download(config restoreCacheConfig) (downloadResult, error) {
 	dir, err := os.MkdirTemp("", "restore-cache")
 	if err != nil {
-		return "", err
+		return downloadResult{}, err
 	}
 	name := fmt.Sprintf("cache-%s.tzst", time.Now().UTC().Format("20060102-150405"))
 	downloadPath := filepath.Join(dir, name)
@@ -153,12 +168,34 @@ func (r *restorer) download(config restoreCacheConfig) (string, error) {
 		CacheKeys:    config.Keys,
 		DownloadPath: downloadPath,
 	}
-	err = network.Download(params, r.logger)
+	matchedKey, err := network.Download(params, r.logger)
 	if err != nil {
-		return "", err
+		return downloadResult{}, err
 	}
 
 	r.logger.Debugf("Archive downloaded to %s", downloadPath)
 
-	return downloadPath, nil
+	return downloadResult{filePath: downloadPath, matchedKey: matchedKey}, nil
+}
+
+func (r *restorer) exposeCacheHit(result downloadResult) error {
+	if result.filePath == "" || result.matchedKey == "" {
+		return nil
+	}
+
+	checksum, err := checksumOfFile(result.filePath)
+	if err != nil {
+		return err
+	}
+
+	r.logger.Debugf("Exposing cache hit info:")
+	r.logger.Debugf("Matched key: %s", result.matchedKey)
+	r.logger.Debugf("Archive checksum: %s", checksum)
+
+	envKey := cacheHitEnvVarPrefix + result.matchedKey
+	err = tools.ExportEnvironmentWithEnvman(envKey, checksum)
+	if err != nil {
+		return err
+	}
+	return r.envRepo.Set(envKey, checksum)
 }

--- a/vendor/github.com/bitrise-io/go-steputils/v2/cache/save.go
+++ b/vendor/github.com/bitrise-io/go-steputils/v2/cache/save.go
@@ -25,6 +25,12 @@ type SaveCacheInput struct {
 	Verbose bool
 	Key     string
 	Paths   []string
+	// IsKeyUnique indicates that the cache key is enough for knowing the cache archive is different from
+	// another cache archive.
+	// This can be set to true if the cache key contains a checksum that changes when any of the cached files change.
+	// Example of such key: my-cache-key-{{ checksum "package-lock.json" }}
+	// Example where this is not true: my-cache-key-{{ .OS }}-{{ .Arch }}
+	IsKeyUnique bool
 }
 
 // Saver ...
@@ -74,6 +80,15 @@ func (s *saver) Save(input SaveCacheInput) error {
 
 	tracker := newStepTracker(input.StepId, s.envRepo, s.logger)
 
+	canSkipSave, reason := s.canSkipSave(input.Key, config.Key, input.IsKeyUnique)
+	s.logger.Println()
+	if canSkipSave {
+		s.logger.Donef("Cache save can be skipped, reason: %s", reason)
+		return nil
+	} else {
+		s.logger.Infof("Can't skip saving the cache, reason: %s", reason)
+	}
+
 	s.logger.Println()
 	s.logger.Infof("Creating archive...")
 	compressionStartTime := time.Now()
@@ -91,6 +106,20 @@ func (s *saver) Save(input SaveCacheInput) error {
 	}
 	s.logger.Printf("Archive size: %s", units.HumanSizeWithPrecision(float64(fileInfo.Size()), 3))
 	s.logger.Debugf("Archive path: %s", archivePath)
+
+	archiveChecksum, err := checksumOfFile(archivePath)
+	if err != nil {
+		s.logger.Warnf(err.Error())
+		// fail silently and continue
+	}
+	canSkipUpload, reason := s.canSkipUpload(config.Key, archiveChecksum)
+	s.logger.Println()
+	if canSkipUpload {
+		s.logger.Donef("Cache upload can be skipped, reason: %s", reason)
+		return nil
+	} else {
+		s.logger.Infof("Can't skip uploading the cache, reason: %s", reason)
+	}
 
 	s.logger.Println()
 	s.logger.Infof("Uploading archive...")
@@ -198,13 +227,7 @@ func (s *saver) evaluatePaths(paths []string) ([]string, error) {
 
 func (s *saver) evaluateKey(keyTemplate string) (string, error) {
 	model := keytemplate.NewModel(s.envRepo, s.logger)
-	buildContext := keytemplate.BuildContext{
-		Workflow:   s.envRepo.Get("BITRISE_TRIGGERED_WORKFLOW_ID"),
-		Branch:     s.envRepo.Get("BITRISE_GIT_BRANCH"),
-		CommitHash: s.envRepo.Get("BITRISE_GIT_COMMIT"),
-	}
-
-	return model.Evaluate(keyTemplate, buildContext)
+	return model.Evaluate(keyTemplate)
 }
 
 func (s *saver) compress(paths []string) (string, error) {

--- a/vendor/github.com/bitrise-io/go-steputils/v2/cache/save_skip.go
+++ b/vendor/github.com/bitrise-io/go-steputils/v2/cache/save_skip.go
@@ -1,0 +1,66 @@
+package cache
+
+import (
+	"fmt"
+	"strings"
+)
+
+func (s *saver) canSkipSave(keyTemplate, evaluatedKey string, onlyCheckCacheKey bool) (canSkip bool, reason string) {
+	if keyTemplate == evaluatedKey {
+		return false, "key is not dynamic; the expectation is that the same key is used for saving different cache contents over and over"
+	}
+
+	cacheHits := s.getCacheHits()
+	if len(cacheHits) == 0 {
+		return false, "no cache was restored in the workflow, creating a new cache entry"
+	}
+
+	if _, ok := cacheHits[evaluatedKey]; ok {
+		if onlyCheckCacheKey {
+			return true, "a cache with the same key was restored in the workflow, new cache would have the same content"
+		} else {
+			return false, "a cache with the same key was restored in the workflow, but contents might have changed since then"
+		}
+	}
+
+	otherKeys := []string{}
+	for k := range cacheHits {
+		otherKeys = append(otherKeys, k)
+	}
+	fullReason := fmt.Sprintf("there was no cache restore in the workflow with this key\nOther restored cache keys found:\n%s", strings.Join(otherKeys, "\n"))
+	return false, fullReason
+}
+
+func (s *saver) canSkipUpload(newCacheKey, newCacheChecksum string) (canSkip bool, reason string) {
+	cacheHits := s.getCacheHits()
+
+	if len(cacheHits) == 0 {
+		return false, "no cache was restored in the workflow"
+	}
+
+	if cacheHits[newCacheKey] == newCacheChecksum {
+		return true, "new cache archive is the same as the restored one"
+	} else {
+		return false, "new cache archive doesn't match the restored one"
+	}
+}
+
+// Returns cache hit information exposed by previous restore cache steps.
+// The returned map's key is the restored cache key, and the value is the checksum of the cache archive
+func (s *saver) getCacheHits() map[string]string {
+	cacheHits := map[string]string{}
+	for _, e := range s.envRepo.List() {
+		envParts := strings.SplitN(e, "=", 2)
+		if len(envParts) < 2 {
+			continue
+		}
+		envKey := envParts[0]
+		envValue := envParts[1]
+
+		if strings.HasPrefix(envKey, cacheHitEnvVarPrefix) {
+			cacheKey := strings.TrimPrefix(envKey, cacheHitEnvVarPrefix)
+			cacheHits[cacheKey] = envValue
+		}
+	}
+	return cacheHits
+}

--- a/vendor/github.com/bitrise-io/go-steputils/v2/cache/tracker.go
+++ b/vendor/github.com/bitrise-io/go-steputils/v2/cache/tracker.go
@@ -62,6 +62,19 @@ func (t *stepTracker) logArchiveExtracted(extractionTime time.Duration, keyCount
 	t.tracker.Enqueue("step_restore_cache_archive_extracted", properties)
 }
 
+func (t *stepTracker) logRestoreResult(isMatch bool, matchedKey string, evaluatedKeys []string) {
+	if len(evaluatedKeys) == 0 {
+		return
+	}
+
+	properties := analytics.Properties{
+		"is_match":             isMatch,
+		"is_first_key_matched": matchedKey == evaluatedKeys[0],
+		"key_count":            len(evaluatedKeys),
+	}
+	t.tracker.Enqueue("step_restore_cache_result", properties)
+}
+
 func (t *stepTracker) wait() {
 	t.tracker.Wait()
 }

--- a/vendor/github.com/bitrise-io/go-utils/command/command.go
+++ b/vendor/github.com/bitrise-io/go-utils/command/command.go
@@ -1,0 +1,252 @@
+package command
+
+import (
+	"errors"
+	"io"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+)
+
+// ----------
+
+// Model ...
+type Model struct {
+	cmd *exec.Cmd
+}
+
+// New ...
+func New(name string, args ...string) *Model {
+	return &Model{
+		cmd: exec.Command(name, args...),
+	}
+}
+
+// NewWithStandardOuts - same as NewCommand, but sets the command's
+// stdout and stderr to the standard (OS) out (os.Stdout) and err (os.Stderr)
+func NewWithStandardOuts(name string, args ...string) *Model {
+	return New(name, args...).SetStdout(os.Stdout).SetStderr(os.Stderr)
+}
+
+// NewWithParams ...
+func NewWithParams(params ...string) (*Model, error) {
+	if len(params) == 0 {
+		return nil, errors.New("no command provided")
+	} else if len(params) == 1 {
+		return New(params[0]), nil
+	}
+
+	return New(params[0], params[1:]...), nil
+}
+
+// NewFromSlice ...
+func NewFromSlice(slice []string) (*Model, error) {
+	return NewWithParams(slice...)
+}
+
+// NewWithCmd ...
+func NewWithCmd(cmd *exec.Cmd) *Model {
+	return &Model{
+		cmd: cmd,
+	}
+}
+
+// GetCmd ...
+func (m *Model) GetCmd() *exec.Cmd {
+	return m.cmd
+}
+
+// SetDir ...
+func (m *Model) SetDir(dir string) *Model {
+	m.cmd.Dir = dir
+	return m
+}
+
+// SetEnvs ...
+func (m *Model) SetEnvs(envs ...string) *Model {
+	m.cmd.Env = envs
+	return m
+}
+
+// AppendEnvs - appends the envs to the current os.Environ()
+// Calling this multiple times will NOT appens the envs one by one,
+// only the last "envs" set will be appended to os.Environ()!
+func (m *Model) AppendEnvs(envs ...string) *Model {
+	return m.SetEnvs(append(os.Environ(), envs...)...)
+}
+
+// SetStdin ...
+func (m *Model) SetStdin(in io.Reader) *Model {
+	m.cmd.Stdin = in
+	return m
+}
+
+// SetStdout ...
+func (m *Model) SetStdout(out io.Writer) *Model {
+	m.cmd.Stdout = out
+	return m
+}
+
+// SetStderr ...
+func (m *Model) SetStderr(err io.Writer) *Model {
+	m.cmd.Stderr = err
+	return m
+}
+
+// Run ...
+func (m Model) Run() error {
+	return m.cmd.Run()
+}
+
+// RunAndReturnExitCode ...
+func (m Model) RunAndReturnExitCode() (int, error) {
+	return RunCmdAndReturnExitCode(m.cmd)
+}
+
+// RunAndReturnTrimmedOutput ...
+func (m Model) RunAndReturnTrimmedOutput() (string, error) {
+	return RunCmdAndReturnTrimmedOutput(m.cmd)
+}
+
+// RunAndReturnTrimmedCombinedOutput ...
+func (m Model) RunAndReturnTrimmedCombinedOutput() (string, error) {
+	return RunCmdAndReturnTrimmedCombinedOutput(m.cmd)
+}
+
+// PrintableCommandArgs ...
+func (m Model) PrintableCommandArgs() string {
+	return PrintableCommandArgs(false, m.cmd.Args)
+}
+
+// ----------
+
+// PrintableCommandArgs ...
+func PrintableCommandArgs(isQuoteFirst bool, fullCommandArgs []string) string {
+	cmdArgsDecorated := []string{}
+	for idx, anArg := range fullCommandArgs {
+		quotedArg := strconv.Quote(anArg)
+		if idx == 0 && !isQuoteFirst {
+			quotedArg = anArg
+		}
+		cmdArgsDecorated = append(cmdArgsDecorated, quotedArg)
+	}
+
+	return strings.Join(cmdArgsDecorated, " ")
+}
+
+// RunCmdAndReturnExitCode ...
+func RunCmdAndReturnExitCode(cmd *exec.Cmd) (exitCode int, err error) {
+	err = cmd.Run()
+	exitCode = cmd.ProcessState.ExitCode()
+	return
+}
+
+// RunCmdAndReturnTrimmedOutput ...
+func RunCmdAndReturnTrimmedOutput(cmd *exec.Cmd) (string, error) {
+	outBytes, err := cmd.Output()
+	outStr := string(outBytes)
+	return strings.TrimSpace(outStr), err
+}
+
+// RunCmdAndReturnTrimmedCombinedOutput ...
+func RunCmdAndReturnTrimmedCombinedOutput(cmd *exec.Cmd) (string, error) {
+	outBytes, err := cmd.CombinedOutput()
+	outStr := string(outBytes)
+	return strings.TrimSpace(outStr), err
+}
+
+// RunCommandWithReaderAndWriters ...
+func RunCommandWithReaderAndWriters(inReader io.Reader, outWriter, errWriter io.Writer, name string, args ...string) error {
+	cmd := exec.Command(name, args...)
+	cmd.Stdin = inReader
+	cmd.Stdout = outWriter
+	cmd.Stderr = errWriter
+	return cmd.Run()
+}
+
+// RunCommandWithWriters ...
+func RunCommandWithWriters(outWriter, errWriter io.Writer, name string, args ...string) error {
+	cmd := exec.Command(name, args...)
+	cmd.Stdout = outWriter
+	cmd.Stderr = errWriter
+	return cmd.Run()
+}
+
+// RunCommandInDirWithEnvsAndReturnExitCode ...
+func RunCommandInDirWithEnvsAndReturnExitCode(envs []string, dir, name string, args ...string) (int, error) {
+	cmd := exec.Command(name, args...)
+	cmd.Stdin = os.Stdin
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	if dir != "" {
+		cmd.Dir = dir
+	}
+	if len(envs) > 0 {
+		cmd.Env = envs
+	}
+
+	return RunCmdAndReturnExitCode(cmd)
+}
+
+// RunCommandInDirAndReturnExitCode ...
+func RunCommandInDirAndReturnExitCode(dir, name string, args ...string) (int, error) {
+	return RunCommandInDirWithEnvsAndReturnExitCode([]string{}, dir, name, args...)
+}
+
+// RunCommandWithEnvsAndReturnExitCode ...
+func RunCommandWithEnvsAndReturnExitCode(envs []string, name string, args ...string) (int, error) {
+	return RunCommandInDirWithEnvsAndReturnExitCode(envs, "", name, args...)
+}
+
+// RunCommandInDir ...
+func RunCommandInDir(dir, name string, args ...string) error {
+	cmd := exec.Command(name, args...)
+	cmd.Stdin = os.Stdin
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	if dir != "" {
+		cmd.Dir = dir
+	}
+	return cmd.Run()
+}
+
+// RunCommand ...
+func RunCommand(name string, args ...string) error {
+	return RunCommandInDir("", name, args...)
+}
+
+// RunCommandAndReturnStdout ..
+func RunCommandAndReturnStdout(name string, args ...string) (string, error) {
+	cmd := exec.Command(name, args...)
+	return RunCmdAndReturnTrimmedOutput(cmd)
+}
+
+// RunCommandInDirAndReturnCombinedStdoutAndStderr ...
+func RunCommandInDirAndReturnCombinedStdoutAndStderr(dir, name string, args ...string) (string, error) {
+	cmd := exec.Command(name, args...)
+	if dir != "" {
+		cmd.Dir = dir
+	}
+	return RunCmdAndReturnTrimmedCombinedOutput(cmd)
+}
+
+// RunCommandAndReturnCombinedStdoutAndStderr ..
+func RunCommandAndReturnCombinedStdoutAndStderr(name string, args ...string) (string, error) {
+	return RunCommandInDirAndReturnCombinedStdoutAndStderr("", name, args...)
+}
+
+// RunBashCommand ...
+func RunBashCommand(cmdStr string) error {
+	return RunCommand("bash", "-c", cmdStr)
+}
+
+// RunBashCommandLines ...
+func RunBashCommandLines(cmdLines []string) error {
+	for _, aLine := range cmdLines {
+		if err := RunCommand("bash", "-c", aLine); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/vendor/github.com/bitrise-io/go-utils/command/file.go
+++ b/vendor/github.com/bitrise-io/go-utils/command/file.go
@@ -1,0 +1,69 @@
+package command
+
+import (
+	"errors"
+	"os"
+	"strings"
+
+	"github.com/bitrise-io/go-utils/pathutil"
+)
+
+// CopyFile ...
+func CopyFile(src, dst string) error {
+	// replace with a pure Go implementation?
+	// Golang proposal was: https://go-review.googlesource.com/#/c/1591/5/src/io/ioutil/ioutil.go
+	isDir, err := pathutil.IsDirExists(src)
+	if err != nil {
+		return err
+	}
+	if isDir {
+		return errors.New("Source is a directory: " + src)
+	}
+	args := []string{src, dst}
+	return RunCommand("rsync", args...)
+}
+
+// CopyDir ...
+func CopyDir(src, dst string, isOnlyContent bool) error {
+	if isOnlyContent && !strings.HasSuffix(src, "/") {
+		src = src + "/"
+	}
+	args := []string{"-ar", src, dst}
+	return RunCommand("rsync", args...)
+}
+
+// RemoveDir ...
+// Deprecated: use RemoveAll instead.
+func RemoveDir(dirPth string) error {
+	if exist, err := pathutil.IsPathExists(dirPth); err != nil {
+		return err
+	} else if exist {
+		if err := os.RemoveAll(dirPth); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// RemoveFile ...
+// Deprecated: use RemoveAll instead.
+func RemoveFile(pth string) error {
+	if exist, err := pathutil.IsPathExists(pth); err != nil {
+		return err
+	} else if exist {
+		if err := os.Remove(pth); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// RemoveAll removes recursively every file on the given paths.
+func RemoveAll(pths ...string) error {
+	for _, pth := range pths {
+		if err := os.RemoveAll(pth); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/vendor/github.com/bitrise-io/go-utils/command/zip.go
+++ b/vendor/github.com/bitrise-io/go-utils/command/zip.go
@@ -1,0 +1,115 @@
+package command
+
+import (
+	"archive/zip"
+	"errors"
+	"io"
+	"log"
+	"net/http"
+	"os"
+	"path/filepath"
+
+	"github.com/bitrise-io/go-utils/pathutil"
+)
+
+// UnZIP ...
+func UnZIP(src, dest string) error {
+	r, err := zip.OpenReader(src)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		if err := r.Close(); err != nil {
+			log.Fatal(err)
+		}
+	}()
+
+	if err := os.MkdirAll(dest, 0755); err != nil {
+		return err
+	}
+
+	// Closure to address file descriptors issue with all the deferred .Close() methods
+	extractAndWriteFile := func(f *zip.File) error {
+		rc, err := f.Open()
+		if err != nil {
+			return err
+		}
+		defer func() {
+			if err := rc.Close(); err != nil {
+				log.Fatal(err)
+			}
+		}()
+
+		path := filepath.Join(dest, f.Name)
+
+		if f.FileInfo().IsDir() {
+			if err := os.MkdirAll(path, f.Mode()); err != nil {
+				return err
+			}
+		} else {
+			f, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, f.Mode())
+			if err != nil {
+				return err
+			}
+			defer func() {
+				if err := f.Close(); err != nil {
+					log.Fatal(err)
+				}
+			}()
+
+			if _, err = io.Copy(f, rc); err != nil {
+				return err
+			}
+		}
+		return nil
+	}
+
+	for _, f := range r.File {
+		if err := extractAndWriteFile(f); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// DownloadAndUnZIP ...
+func DownloadAndUnZIP(url, pth string) error {
+	tmpDir, err := pathutil.NormalizedOSTempDirPath("")
+	if err != nil {
+		return err
+	}
+	srcFilePath := tmpDir + "/target.zip"
+	srcFile, err := os.Create(srcFilePath)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		if err := srcFile.Close(); err != nil {
+			log.Fatal("Failed to close srcFile:", err)
+		}
+		if err := os.Remove(srcFilePath); err != nil {
+			log.Fatal("Failed to remove srcFile:", err)
+		}
+	}()
+
+	response, err := http.Get(url)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		if err := response.Body.Close(); err != nil {
+			log.Fatal("Failed to close response body:", err)
+		}
+	}()
+
+	if response.StatusCode != http.StatusOK {
+		errorMsg := "Failed to download target from: " + url
+		return errors.New(errorMsg)
+	}
+
+	if _, err := io.Copy(srcFile, response.Body); err != nil {
+		return err
+	}
+
+	return UnZIP(srcFilePath, pth)
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1,4 +1,7 @@
-# github.com/bitrise-io/go-steputils/v2 v2.0.0-alpha.11
+# github.com/bitrise-io/go-steputils v1.0.1
+## explicit; go 1.15
+github.com/bitrise-io/go-steputils/tools
+# github.com/bitrise-io/go-steputils/v2 v2.0.0-alpha.13
 ## explicit; go 1.16
 github.com/bitrise-io/go-steputils/v2/cache
 github.com/bitrise-io/go-steputils/v2/cache/compression
@@ -8,6 +11,7 @@ github.com/bitrise-io/go-steputils/v2/stepconf
 # github.com/bitrise-io/go-utils v1.0.1
 ## explicit; go 1.13
 github.com/bitrise-io/go-utils/colorstring
+github.com/bitrise-io/go-utils/command
 github.com/bitrise-io/go-utils/parseutil
 github.com/bitrise-io/go-utils/pathutil
 github.com/bitrise-io/go-utils/pointers


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our Step library!
  Please fill this template with the details of your change.
-->

### Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. This is simply a reminder of what we are going to look
  for before merging your code.
-->
- [ ] I've read and followed the [Contribution Guidelines](https://github.com/bitrise-steplib/.github/blob/main/CONTRIBUTING.md)
- [ ] `step.yml` and `README.md` is updated with the changes (if needed)

### Version
<!-- Leave this untouched if you don't know, we'll help -->
Requires a *MAJOR/MINOR/PATCH* [version update](https://semver.org/)

### Context

See https://github.com/bitrise-io/go-steputils/pull/67

### Changes

- Bump `go-steputils` to get the latest shared cache implementation
- Add new input: `is_key_unique`
- Update step description, README

New feature in action (see the E2E test logs for more details):

```
+------------------------------------------------------------------------------+
| (5) Execute step after restore                                               |
+------------------------------------------------------------------------------+
| id: ./                                                                       |
| version:                                                                     |
| collection: path                                                             |
| toolkit: go                                                                  |
| time: 2022-10-13T10:52:31Z                                                   |
+------------------------------------------------------------------------------+
|                                                                              |
Input:
- verbose: true
- key: node-modules-{{ checksum "package-lock.json" }}
- paths: node_modules
- is_key_unique: true
Evaluating key template: node-modules-{{ checksum "package-lock.json" }}
Files included in checksum:
- package-lock.json
Cache key: node-modules-9175abe5aea83e3c16254f8eb7446bb62b062dbf6bf77c79839f33db991de359
Cache save can be skipped, reason: a cache with the same key was restored in the workflow, new cache would have the same content
|                                                                              |
+---+---------------------------------------------------------------+----------+
| ✓ | Execute step after restore                                    | 1.92 sec |
+---+---------------------------------------------------------------+----------+
```

### Investigation details

<!-- Please share any alternative solutions that were considered along with investigation details. -->

### Decisions

<!-- Please list decisions that were made for this change. -->
